### PR TITLE
Update Nissan Xterra generations: Added references and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# Nissan Xterra
+
+This repository contains signal set configurations for the Nissan Xterra, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Nissan Xterra.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Nissan_Xterra"
+
 generations:
   - name: "First Generation (WD22)"
     start_year: 2000


### PR DESCRIPTION
- Added Wikipedia reference to generations.yaml
- Updated README.md with standard vehicle template
- Verified generational data matches Wikipedia article (WD22: 2000-2004, N50: 2005-2015)
